### PR TITLE
Adds Content-Length header in simple app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .bin
 /bin
+/build

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gabriel-vasile/mimetype v1.1.1 h1:qbN9MPuRf3bstHu9zkI9jDWNfH//9+9kHxr9oRBBBOA=
 github.com/gabriel-vasile/mimetype v1.1.1/go.mod h1:6CDPel/o/3/s4+bp6kIbsWATq8pmgOisOPG40CJa6To=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -85,7 +85,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 
 				content, err := ioutil.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(content)).To(ContainSubstring("Hello world!"))
+				Expect(string(content)).To(Equal("Hello world!"))
 
 				Expect(logs).To(ContainLines(
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),

--- a/integration/testdata/simple_app/config.ru
+++ b/integration/testdata/simple_app/config.ru
@@ -1,2 +1,7 @@
-require './hello'
+class HelloWorld
+  def call(env)
+    [200, {"Content-Type" => "text/plain", "Content-Length" => "12"}, ["Hello world!"]]
+  end
+end
+
 run HelloWorld.new

--- a/integration/testdata/simple_app/hello.rb
+++ b/integration/testdata/simple_app/hello.rb
@@ -1,5 +1,0 @@
-class HelloWorld
-  def call(env)
-    [200, {"Content-Type" => "text/plain"}, ["Hello world!"]]
-  end
-end


### PR DESCRIPTION
The simple app in the integration test suite was accidentally emitting a response that used chunked transfer encoding. This resulted in response bodies that had strange extra characters. This is the default behavior for Rack when the response headers do not include a Content-Length header. This [Stack Overflow post](https://stackoverflow.com/questions/23128957/strange-extra-characters-in-rails-response-body) explains the issue a bit more.

Resolves #75