### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -2,7 +2,6 @@ package rackup
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,7 +23,7 @@ func Build(logger scribe.Logger) packit.BuildFunc {
 		}
 
 		// check if the config.ru file specifies a port
-		configru, err := ioutil.ReadFile(filepath.Join(context.WorkingDir, "config.ru"))
+		configru, err := os.ReadFile(filepath.Join(context.WorkingDir, "config.ru"))
 		if err != nil {
 			return packit.BuildResult{}, fmt.Errorf("failed to read config.ru: %w", err)
 		}
@@ -57,6 +56,7 @@ func Build(logger scribe.Logger) packit.BuildFunc {
 					{
 						Type:    "web",
 						Command: command,
+						Default: true,
 					},
 				},
 			},

--- a/build_test.go
+++ b/build_test.go
@@ -2,7 +2,6 @@ package rackup_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,13 +28,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layersDir, err = ioutil.TempDir("", "layers")
+		layersDir, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = ioutil.TempDir("", "cnb")
+		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		buffer = bytes.NewBuffer(nil)
@@ -52,9 +51,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when there is a config.ru file that doesn't specify a port", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "config.ru"), []byte{}, 0644)
+			err := os.WriteFile(filepath.Join(workingDir, "config.ru"), []byte{}, 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 		it("returns a result that provides a start command that uses $PORT", func() {
 			result, err := build(packit.BuildContext{
 				WorkingDir: workingDir,
@@ -81,6 +81,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: `bundle exec rackup --env RACK_ENV=production -p "${PORT:-9292}"`,
+							Default: true,
 						},
 					},
 				},
@@ -93,9 +94,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when there is a config.ru file that specifies a port via -p", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "config.ru"), []byte(`#\ -o 0.0.0.0 -p 3000`), 0644)
+			err := os.WriteFile(filepath.Join(workingDir, "config.ru"), []byte(`#\ -o 0.0.0.0 -p 3000`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 		it("returns a result that provides a start command that looks in the config.ru file for port configurations", func() {
 			result, err := build(packit.BuildContext{
 				WorkingDir: workingDir,
@@ -122,6 +124,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: `bundle exec rackup --env RACK_ENV=production -p "${PORT:-3000}"`,
+							Default: true,
 						},
 					},
 				},
@@ -134,9 +137,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when there is a config.ru file that specifies a port via --port", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(workingDir, "config.ru"), []byte(`#\ --port 3000`), 0644)
+			err := os.WriteFile(filepath.Join(workingDir, "config.ru"), []byte(`#\ --port 3000`), 0600)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 		it("returns a result that provides a start command that looks in the config.ru file for port configurations", func() {
 			result, err := build(packit.BuildContext{
 				WorkingDir: workingDir,
@@ -163,6 +167,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: `bundle exec rackup --env RACK_ENV=production -p "${PORT:-3000}"`,
+							Default: true,
 						},
 					},
 				},
@@ -172,6 +177,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(buffer.String()).To(ContainSubstring("Writing start command"))
 		})
 	})
+
 	context("failure cases", func() {
 		context("when unable to stat config.ru", func() {
 			it.Before(func() {

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/rackup"

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,7 +2,6 @@ package rackup_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,13 +25,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(filepath.Join(workingDir, "Gemfile"), []byte{}, 0644)
+		err = os.WriteFile(filepath.Join(workingDir, "Gemfile"), nil, 0600)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(filepath.Join(workingDir, "config.ru"), []byte{}, 0644)
+		err = os.WriteFile(filepath.Join(workingDir, "config.ru"), nil, 0600)
 		Expect(err).NotTo(HaveOccurred())
 
 		gemfileLockParser = &fakes.GemParser{}

--- a/gemfile_lock_parser_test.go
+++ b/gemfile_lock_parser_test.go
@@ -1,7 +1,6 @@
 package rackup_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -20,7 +19,7 @@ func testGemfileLockParser(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		file, err := ioutil.TempFile("", "Gemfile.lock")
+		file, err := os.CreateTemp("", "Gemfile.lock")
 		Expect(err).NotTo(HaveOccurred())
 		defer file.Close()
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
