### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rackup Cloud Native Buildpack
+# Paketo Buildpack for Rackup
 
 ## `gcr.io/paketo-buildpacks/rackup`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/rackup"
   id = "paketo-buildpacks/rackup"
   keywords = ["ruby", "rackup"]
-  name = "Paketo Rackup Buildpack"
+  name = "Paketo Buildpack for Rackup"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Rackup Buildpack' to 'Paketo Buildpack for Rackup'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
