### PR TITLE
🐞 fix value passed to `--env`

### DIFF
--- a/build.go
+++ b/build.go
@@ -43,12 +43,12 @@ func Build(logger scribe.Emitter) packit.BuildFunc {
 		}
 		logger.Debug.Break()
 
-		// Use RACK_ENV=production since Rack v1.6.0+ defaults the host to local host in development mode (default)
+		// Hardcode `--env production` since Rack v1.6.0+ defaults the host to local host in development mode (default)
 		// The order of precedence in setting the port is:
 		// 1. the $PORT variable if it is set
 		// 2. A port listed in config.ru with the -p or --port flag
 		// 3. 1 and 2 are not met, and the fallback port is set to the default of 9292.
-		args := fmt.Sprintf(`bundle exec rackup --env RACK_ENV=production -p "${PORT:-%s}"`, port)
+		args := fmt.Sprintf(`bundle exec rackup --env %s -p "${PORT:-%s}"`, "production", port)
 		processes := []packit.Process{
 			{
 				Type:    "web",

--- a/build_test.go
+++ b/build_test.go
@@ -81,7 +81,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: "bash",
-							Args:    []string{"-c", `bundle exec rackup --env RACK_ENV=production -p "${PORT:-9292}"`},
+							Args:    []string{"-c", `bundle exec rackup --env production -p "${PORT:-9292}"`},
 							Default: true,
 							Direct:  true,
 						},
@@ -126,7 +126,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: "bash",
-							Args:    []string{"-c", `bundle exec rackup --env RACK_ENV=production -p "${PORT:-3000}"`},
+							Args:    []string{"-c", `bundle exec rackup --env production -p "${PORT:-3000}"`},
 							Default: true,
 							Direct:  true,
 						},
@@ -175,7 +175,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						{
 							Type:    "web",
 							Command: "bash",
-							Args:    []string{"-c", `bundle exec rackup --env RACK_ENV=production -p "${PORT:-3000}"`},
+							Args:    []string{"-c", `bundle exec rackup --env production -p "${PORT:-3000}"`},
 							Default: true,
 							Direct:  true,
 						},

--- a/integration/config_port_app_test.go
+++ b/integration/config_port_app_test.go
@@ -84,7 +84,7 @@ func testConfigPortApp(t *testing.T, context spec.G, it spec.S) {
 					"    config.ru specifies a port: 3000",
 					"",
 					"  Assigning launch processes:",
-					`    web (default): bash -c bundle exec rackup --env RACK_ENV=production -p "${PORT:-3000}"`,
+					`    web (default): bash -c bundle exec rackup --env production -p "${PORT:-3000}"`,
 				))
 
 				Eventually(func() string {
@@ -133,7 +133,7 @@ func testConfigPortApp(t *testing.T, context spec.G, it spec.S) {
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 					"  Writing start command",
 					"  Assigning launch processes:",
-					`    web (default): bash -c bundle exec rackup --env RACK_ENV=production -p "${PORT:-3000}"`,
+					`    web (default): bash -c bundle exec rackup --env production -p "${PORT:-3000}"`,
 				))
 
 				Eventually(func() string {

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -81,7 +81,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 					"  Writing start command",
 					"  Assigning launch processes:",
-					`    web (default): bash -c bundle exec rackup --env RACK_ENV=production -p "${PORT:-9292}"`,
+					`    web (default): bash -c bundle exec rackup --env production -p "${PORT:-9292}"`,
 				))
 			})
 		})
@@ -117,7 +117,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 					"  Writing start command",
 					"  Assigning launch processes:",
-					`    web (default): bash -c bundle exec rackup --env RACK_ENV=production -p "${PORT:-9292}"`,
+					`    web (default): bash -c bundle exec rackup --env production -p "${PORT:-9292}"`,
 				))
 			})
 		})

--- a/integration/sinatra_app_test.go
+++ b/integration/sinatra_app_test.go
@@ -80,7 +80,7 @@ func testSinatraApp(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Writing start command",
 				"  Assigning launch processes:",
-				`    web (default): bash -c bundle exec rackup --env RACK_ENV=production -p "${PORT:-9292}"`,
+				`    web (default): bash -c bundle exec rackup --env production -p "${PORT:-9292}"`,
 			))
 		})
 	})


### PR DESCRIPTION
## Summary
Pass `production`, and not `RACK_ENV=production` to `rackup`'s `--env` flag.

The rack environment is hard-coded to the value `RACK_ENV=production` which appears to be a conflation of setting an ENV variable, and passing the value value via the `--env` flag to `rackup`.

This commit makes two changes:
1. The value passed to the flag `--env` is now `production`, not `RACK_ENV=production`, and changes to the associated tests.
2. The value `production`, while still hard-coded, is interpolated into the process args. This should make it easier to make the value dynamic in the future. See https://github.com/paketo-buildpacks/rackup/issues/281

Addresses https://github.com/paketo-buildpacks/rackup/issues/355

cc @dsabeti

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
